### PR TITLE
README: add 30-second quickstart + positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Budgeted LLM tasks that scale beyond context.
 
 enzu is a Python-first toolkit for AI engineers and builders who need reliable, budgeted LLM runs. It enforces hard limits (tokens, time, cost), switches to RLM when context is large, and works across OpenAI-compatible providers. Use it from Python, the CLI, or the HTTP API.
 
+## 30-second quickstart
+
+```bash
+uv add enzu
+export OPENAI_API_KEY=sk-...
+python -c "from enzu import ask; print(ask('Say hello in one sentence.'))"
+```
+
+## What enzu is (and isn’t)
+
+- **Enzu is** a *budget + reliability layer* for LLM work: caps that actually stop execution when you hit token/time/cost limits.
+- **Enzu isn’t** a giant agent framework. It’s meant to stay small, composable, and easy to drop into existing code.
+
 ## Why enzu
 
 - **Hard budgets by default**: tokens, time, and cost caps that actually stop work


### PR DESCRIPTION
This PR improves first-impression conversion (stars) by:

- Adding a 30-second quickstart block
- Clarifying what enzu is (and isn’t) to reduce framework confusion

Goal: make the repo instantly legible in <15 seconds for new visitors.

## Summary by Sourcery

Improve the README to better explain enzu and provide a fast on-ramp for new users.

Documentation:
- Add a 30-second quickstart snippet showing installation, API key configuration, and a minimal usage example.
- Clarify enzu’s positioning by explicitly describing what it is and is not to avoid confusion with larger agent frameworks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime behavior, APIs, or security-sensitive logic is modified.
> 
> **Overview**
> Adds a new **30-second quickstart** to `README.md` with minimal install/env setup and a one-line `ask()` example.
> 
> Clarifies product positioning via a new **“What enzu is (and isn’t)”** section to distinguish it from larger agent frameworks and emphasize budget/reliability guardrails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 982037a5740ab14a868df61b115ea18f0cfab39d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->