### PR TITLE
RLM: treat salvaged partial answers as budget_exceeded

### DIFF
--- a/enzu/rlm/runner.py
+++ b/enzu/rlm/runner.py
@@ -592,9 +592,16 @@ class StepRunner:
             except Exception:
                 pass
 
+        # Partial if answer was salvaged (budget exhausted before FINAL)
+        partial = salvaged and bool(answer)
+
         # Determine typed outcome
-        # Note: budget_exceeded error may have been removed if answer was salvaged
-        if success:
+        # Key invariant: if we had to salvage because we ran out of budget before FINAL(),
+        # treat it as budget exhaustion (even if mechanical verification passed).
+        if partial:
+            outcome = Outcome.BUDGET_EXCEEDED
+            success = False
+        elif success:
             outcome = Outcome.SUCCESS
         elif "budget_exceeded" in errors or bool(budget_usage.limits_exceeded):
             outcome = Outcome.BUDGET_EXCEEDED
@@ -608,9 +615,6 @@ class StepRunner:
             outcome = Outcome.TOOL_ERROR
         else:
             outcome = Outcome.PROVIDER_ERROR
-
-        # Partial if answer was salvaged (budget exhausted before FINAL)
-        partial = salvaged and bool(answer)
 
         telemetry.log(
             "info",


### PR DESCRIPTION
Fixes a misleading invariant:

- Previously, RLM runs that exhausted budget *before FINAL()* could be marked Outcome.SUCCESS if mechanical verification passed.
- This makes typed outcomes unreliable for production and confuses the demos.

Change:
- If the run is  because we salvaged output after budget exhaustion, set  and .

Acceptance:
-  prints  when using a tiny token budget.

## Summary by Sourcery

Bug Fixes:
- Ensure runs that salvage answers after token budget exhaustion are reported as budget_exceeded rather than successful, even if mechanical verification passes.